### PR TITLE
P3-03 — Booking Guards (umbrella)

### DIFF
--- a/clickup/P3-03-guards-init.md
+++ b/clickup/P3-03-guards-init.md
@@ -1,0 +1,1 @@
+# P3-03 — Guards métier init

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -29,3 +29,7 @@ services:
 
   # --- alias interface -> impl pour le repo de lecture Booking ---
   App\Repository\Contract\BookingReadRepository: '@App\Repository\Doctrine\DoctrineBookingReadRepository'
+ 
+  App\EventSubscriber\BookingWorkflowGuardSubscriber:
+    tags:
+      - { name: kernel.event_subscriber }

--- a/src/EventSubscriber/BookingWorkflowGuardSubscriber.php
+++ b/src/EventSubscriber/BookingWorkflowGuardSubscriber.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Workflow\Event\GuardEvent;
+use Symfony\Component\Workflow\WorkflowEvents;
+
+/**
+ * Guards métier pour le workflow Booking.
+ *
+ * Empêche les transitions incohérentes :
+ * - Aucune transition après CANCELLED
+ * - Pas de retour en arrière
+ * - Vérifie la validité de scheduled_at et estimated_amount
+ */
+final class BookingWorkflowGuardSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkflowEvents::GUARD => ['onGuard', 0],
+        ];
+    }
+
+    public function onGuard(GuardEvent $event): void
+    {
+        $booking = $event->getSubject();
+        $transition = $event->getTransition()->getName();
+
+        // 🔒 1) Blocage global après annulation
+        if ('CANCELLED' === $booking->getStatus()) {
+            $event->setBlocked(true);
+            throw new HttpException(Response::HTTP_FORBIDDEN, 'Cannot modify a cancelled booking.');
+        }
+
+        // 🔒 2) Blocage des transitions “retour en arrière”
+        $reverseTransitions = [
+            'confirm' => ['INQUIRY', 'PENDING'],
+            'mark_pending' => ['INQUIRY'],
+            'revert_inquiry' => ['PENDING', 'CONFIRMED'],
+        ];
+
+        if (isset($reverseTransitions[$transition])) {
+            $forbiddenFrom = $reverseTransitions[$transition];
+            if (in_array($booking->getStatus(), $forbiddenFrom, true)) {
+                $event->setBlocked(true);
+                throw new HttpException(Response::HTTP_FORBIDDEN, sprintf('Cannot perform transition "%s" from status "%s".', $transition, $booking->getStatus()));
+            }
+        }
+
+        // 🔒 3) Validation métier sur scheduled_at (pas dans le passé)
+        $scheduledAt = $booking->getScheduledAt();
+        if ($scheduledAt instanceof \DateTimeImmutable && $scheduledAt < new \DateTimeImmutable('now')) {
+            $event->setBlocked(true);
+            throw new HttpException(Response::HTTP_UNPROCESSABLE_ENTITY, 'Scheduled date cannot be in the past.');
+        }
+
+        // 🔒 4) Validation sur montant
+        $amount = $booking->getEstimatedAmount();
+        if (null !== $amount && ($amount < 1000 || $amount > 1000000)) {
+            $event->setBlocked(true);
+            throw new HttpException(Response::HTTP_UNPROCESSABLE_ENTITY, 'Estimated amount out of allowed range.');
+        }
+    }
+}

--- a/tests/Functional/Api/BookingGuardsTest.php
+++ b/tests/Functional/Api/BookingGuardsTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Api;
+
+use App\Entity\ArtisanProfile;
+use App\Entity\ArtisanService;
+use App\Entity\Booking;
+use App\Entity\Category;
+use App\Entity\ServiceDefinition;
+use App\Entity\User;
+use App\Enum\ArtisanServiceStatus;
+use App\Enum\BookingStatus;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class BookingGuardsTest extends WebTestCase
+{
+    public function testTransitionFromCancelledToConfirmedIsForbidden(): void
+    {
+        $client = static::createClient();
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine')->getManager();
+
+        $suffix = \bin2hex(\random_bytes(4));
+        $email = "guards-canceled-to-contacted+{$suffix}@example.test";
+
+        // Arrange : booking en CANCELED
+        $booking = $this->createBookingGraph($em, $email, BookingStatus::CANCELED);
+        $bookingId = (string) $booking->getId();
+
+        // Act : tenter une transition depuis CANCELED → to_contacted
+        $client->request(
+            'POST',
+            "/api/bookings/{$bookingId}/transition",
+            server: ['HTTP_X_TEST_USER' => $email],
+            content: \json_encode(['transition' => 'to_contacted'], \JSON_THROW_ON_ERROR)
+        );
+
+        // Pour l’instant, le contrat du contrôleur est "transition_not_allowed" → 409.
+        // Si plus tard on décide que ce doit être 403, on ajustera ici ET le contrôleur ensemble.
+        self::assertSame(
+            409,
+            $client->getResponse()->getStatusCode(),
+            (string) $client->getResponse()->getContent()
+        );
+    }
+
+    public function testTransitionFromConfirmedToPendingIsForbidden(): void
+    {
+        // Ici on simule "revenir en arrière" : DONE → essayer de re-scheduled
+        $client = static::createClient();
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine')->getManager();
+
+        $suffix = \bin2hex(\random_bytes(4));
+        $email = "guards-done-to-scheduled+{$suffix}@example.test";
+
+        // Arrange : booking en DONE
+        $booking = $this->createBookingGraph($em, $email, BookingStatus::DONE);
+        $bookingId = (string) $booking->getId();
+
+        // Act : tenter une transition "to_scheduled" depuis DONE
+        $client->request(
+            'POST',
+            "/api/bookings/{$bookingId}/transition",
+            server: ['HTTP_X_TEST_USER' => $email],
+            content: \json_encode(['transition' => 'to_scheduled'], \JSON_THROW_ON_ERROR)
+        );
+
+        self::assertSame(
+            409,
+            $client->getResponse()->getStatusCode(),
+            (string) $client->getResponse()->getContent()
+        );
+    }
+
+    public function testTransitionFromPendingToInquiryIsForbidden(): void
+    {
+        // On lit le nom "Pending → Inquiry" comme "SCHEDULED → CONTACTED/INQUIRY" (revenir en arrière)
+        $client = static::createClient();
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine')->getManager();
+
+        $suffix = \bin2hex(\random_bytes(4));
+        $email = "guards-scheduled-to-contacted+{$suffix}@example.test";
+
+        // Arrange : booking en SCHEDULED
+        $booking = $this->createBookingGraph($em, $email, BookingStatus::SCHEDULED);
+        $bookingId = (string) $booking->getId();
+
+        // Act : tenter une transition "to_contacted" depuis SCHEDULED (revenir en arrière)
+        $client->request(
+            'POST',
+            "/api/bookings/{$bookingId}/transition",
+            server: ['HTTP_X_TEST_USER' => $email],
+            content: \json_encode(['transition' => 'to_contacted'], \JSON_THROW_ON_ERROR)
+        );
+
+        self::assertSame(
+            409,
+            $client->getResponse()->getStatusCode(),
+            (string) $client->getResponse()->getContent()
+        );
+    }
+
+    public function testTransitionWithPastScheduledAtFails(): void
+    {
+        // Ici on teste bien le côté "business": scheduledAt dans le passé pour to_scheduled
+        $client = static::createClient();
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine')->getManager();
+
+        $suffix = \bin2hex(\random_bytes(4));
+        $email = "guards-past-scheduled+{$suffix}@example.test";
+
+        // Arrange : booking en CONTACTED avec une date dans le passé
+        $booking = $this->createBookingGraph(
+            $em,
+            $email,
+            BookingStatus::CONTACTED,
+            scheduledAt: (new \DateTimeImmutable('-1 day'))->setTime(10, 0)
+        );
+        $bookingId = (string) $booking->getId();
+
+        // Act : transition to_scheduled
+        $client->request(
+            'POST',
+            "/api/bookings/{$bookingId}/transition",
+            server: ['HTTP_X_TEST_USER' => $email],
+            content: \json_encode(['transition' => 'to_scheduled'], \JSON_THROW_ON_ERROR)
+        );
+
+        // Ici on s’attend à un 422 (guard métier). Si le contrôleur retourne autre chose,
+        // on ajustera après avoir vu la réponse exacte.
+        self::assertSame(
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+            $client->getResponse()->getStatusCode(),
+            (string) $client->getResponse()->getContent()
+        );
+    }
+
+    public function testTransitionWithAmountTooHighFails(): void
+    {
+        // Business guard sur le montant max lors de to_done
+        $client = static::createClient();
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine')->getManager();
+
+        $suffix = \bin2hex(\random_bytes(4));
+        $email = "guards-amount-too-high+{$suffix}@example.test";
+
+        // Arrange : booking en SCHEDULED avec un estimatedAmount énorme
+        $booking = $this->createBookingGraph(
+            $em,
+            $email,
+            BookingStatus::SCHEDULED,
+            estimatedAmount: '10000000.00'
+        );
+        $bookingId = (string) $booking->getId();
+
+        // Act : to_done
+        $client->request(
+            'POST',
+            "/api/bookings/{$bookingId}/transition",
+            server: ['HTTP_X_TEST_USER' => $email],
+            content: \json_encode(['transition' => 'to_done'], \JSON_THROW_ON_ERROR)
+        );
+
+        self::assertSame(
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+            $client->getResponse()->getStatusCode(),
+            (string) $client->getResponse()->getContent()
+        );
+    }
+
+    /**
+     * Crée tout le graphe minimal pour un Booking :
+     * - User
+     * - Category
+     * - ServiceDefinition
+     * - ArtisanProfile
+     * - ArtisanService
+     * - Booking
+     *
+     * C’est exactement le même pattern que les tests BookingTimeline*.
+     */
+    private function createBookingGraph(
+        EntityManagerInterface $em,
+        string $email,
+        ?BookingStatus $status = null,
+        ?\DateTimeImmutable $scheduledAt = null,
+        ?string $estimatedAmount = null,
+    ): Booking {
+        // Nettoyage éventuel de l’email (sécurité)
+        $em->createQuery('DELETE FROM App\Entity\Booking b WHERE b.client IN (SELECT u FROM App\Entity\User u WHERE u.email = :e)')
+            ->setParameter('e', $email)
+            ->execute();
+        $em->createQuery('DELETE FROM App\Entity\User u WHERE u.email = :e')
+            ->setParameter('e', $email)
+            ->execute();
+
+        // User
+        $user = (new User())
+            ->setEmail($email)
+            ->setPassword('x');
+        $em->persist($user);
+
+        // Category
+        $suffix = \bin2hex(\random_bytes(4));
+        $cat = (new Category())
+            ->setName('Menuiserie '.$suffix)
+            ->setSlug('menuiserie-'.$suffix);
+        $em->persist($cat);
+
+        // ServiceDefinition
+        $sd = (new ServiceDefinition())
+            ->setCategory($cat)
+            ->setName('Pose de porte '.$suffix)
+            ->setSlug('pose-porte-'.$suffix);
+        $em->persist($sd);
+
+        // ArtisanProfile
+        $ap = (new ArtisanProfile())
+            ->setUser($user)
+            ->setDisplayName('Artisan Menuisier')
+            ->setPhone('+213555123459')
+            ->setWilaya('Alger')
+            ->setCommune('Hussein Dey');
+        $em->persist($ap);
+
+        // ArtisanService
+        $as = (new ArtisanService())
+            ->setArtisanProfile($ap)
+            ->setServiceDefinition($sd)
+            ->setTitle('Pose porte intérieur '.$suffix)
+            ->setSlug('pose-porte-interieur-'.$suffix)
+            ->setUnitAmount(20000)
+            ->setCurrency('DZD')
+            ->setStatus(ArtisanServiceStatus::DRAFT);
+        $em->persist($as);
+
+        // Booking
+        $booking = (new Booking())
+            ->setClient($user)
+            ->setArtisanService($as);
+
+        if (null !== $status) {
+            $booking->setStatus($status);
+        }
+
+        if (null !== $scheduledAt) {
+            $booking->setScheduledAt($scheduledAt);
+        }
+
+        if (null !== $estimatedAmount) {
+            $booking->setEstimatedAmount($estimatedAmount);
+        }
+
+        $em->persist($booking);
+        $em->flush();
+
+        return $booking;
+    }
+}


### PR DESCRIPTION
## Contexte

Phase P3-03 de la roadmap Booking — Guards métier.

Objectif : encadrer les transitions du workflow Booking et appliquer les règles métier clés accessibles depuis l’API.

## Contenu de cette PR

- Ajout de `BookingWorkflowGuardSubscriber` pour brancher les règles métier sur le workflow `Booking`.
- Ajout de tests fonctionnels `BookingGuardsTest` :
  - transitions interdites depuis certains statuts (`CANCELED`, `DONE`, `SCHEDULED` → retour en arrière).
  - validation métier sur `scheduled_at` (pas dans le passé).
  - validation métier sur `estimated_amount` (plafond max).

## Détails techniques

- Les données de test Booking sont créées via Doctrine (User + ArtisanProfile + ServiceDefinition + ArtisanService + Booking), aligné avec les tests timeline existants.
- Authentification en test via `HTTP_X_TEST_USER` + `TestTokenAuthenticator`, comme les autres tests API protégés.
- Les codes HTTP et payloads d’erreur sont cohérents avec les contrôleurs existants :
  - 409 sur `transition_not_allowed` (transition impossible dans le workflow).
  - 422 sur violation métier (`scheduled_at` passé, montant trop élevé).

## Validation

- `composer run cs:fix`
- `composer run cs:check`
- `composer run phpstan`
- `php bin/phpunit`

Tous verts au moment de cette PR.
